### PR TITLE
Updates to Brave 4.8/ Zipkin Reporter 2

### DIFF
--- a/brave-kafka/src/test/java/smartthings/brave/kafka/consumers/DefaultTracingConsumerInterceptorTest.java
+++ b/brave-kafka/src/test/java/smartthings/brave/kafka/consumers/DefaultTracingConsumerInterceptorTest.java
@@ -29,9 +29,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import smartthings.brave.kafka.EnvelopeProtos;
-import zipkin.reporter.Reporter;
 import zipkin2.Endpoint;
 import zipkin2.Span;
+import zipkin2.reporter.Reporter;
 
 import java.util.UUID;
 

--- a/brave-kafka/src/test/java/smartthings/brave/kafka/producers/DefaultTracingProducerInterceptorTest.java
+++ b/brave-kafka/src/test/java/smartthings/brave/kafka/producers/DefaultTracingProducerInterceptorTest.java
@@ -23,8 +23,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.Before;
 import org.junit.Test;
 import smartthings.brave.kafka.EnvelopeProtos;
-import zipkin.reporter.Reporter;
 import zipkin2.Endpoint;
+import zipkin2.reporter.Reporter;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;

--- a/brave-metrics-dropwizard/src/main/java/smartthings/brave/metrics/DropwizardReporterMetrics.java
+++ b/brave-metrics-dropwizard/src/main/java/smartthings/brave/metrics/DropwizardReporterMetrics.java
@@ -17,7 +17,7 @@ package smartthings.brave.metrics;
 import com.codahale.metrics.MetricRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import zipkin.reporter.ReporterMetrics;
+import zipkin2.reporter.ReporterMetrics;
 
 public final class DropwizardReporterMetrics implements ReporterMetrics {
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <main.basedir>${project.basedir}</main.basedir>
     <zipkin.version>2.0.0</zipkin.version>
-    <brave.version>4.7.1</brave.version>
-    <brave-cassandra.version>0.2.0</brave-cassandra.version>
+    <brave.version>4.8.0</brave.version>
+    <brave-cassandra.version>0.3.0</brave-cassandra.version>
     <cassandra-driver.version>3.2.0</cassandra-driver.version>
     <log4j.version>2.3</log4j.version>
     <httpcomponents.version>4.4.1</httpcomponents.version>


### PR DESCRIPTION
This drops the dependency on v1 of zipkin-reporter eventhough you can still write the old format if you want like..

```
reporter = AsyncReporter.builder(URLConnectionSender.create("http://localhost:9411/api/v1/spans"))
                        .build(SpanBytesEncoder.JSON_V1);
```