### PR TITLE
Added support for tracing via SNS message attributes

### DIFF
--- a/brave-sns/README.md
+++ b/brave-sns/README.md
@@ -1,0 +1,57 @@
+
+## SmartThings Brave SNS #
+
+Implements trace propagation through AWS SNS topics via a message's MessageAttributes.  At this time, only the PublishRequest 
+is instrumented.
+
+### Usage
+
+Register the PublishRequestTracingHandler (along with any other request handlers) when building the AmazonSNS client:
+
+    AmazonSNS client = AmazonSNSClientBuilder
+        .standard()
+        .withRequestHandlers(new PublishRequestTracingHandler(httpTracing.tracing()))
+        .build()
+
+Issue a publish request:
+
+    PublishRequest publishRequest = new PublishRequest()
+        .withTopicArn(topicArn)
+        .withMessage(messageBody)
+        
+    client.publish(publishRequest)
+
+The resulting published message will have trace and span information in the MessageAttributes 
+along with the standard SNS message attributes
+
+    "MessageAttributes": {
+        "X-B3-Sampled": {
+            "DataType": "String", 
+            "StringValue": "1"
+        }, 
+        "X-B3-ParentSpanId": {
+            "DataType": "String", 
+            "StringValue": "1493c431c9630d6a"
+        },
+        "X-B3-TraceId": {
+            "DataType": "String", 
+            "StringValue": "1493c431c9630d6a"
+        }, 
+        "X-B3-SpanId": {
+            "DataType": "String", 
+            "StringValue": "73b3a8a29991455a"
+        }, 
+    }
+
+### Topic Configuration
+
+By default, SNS will not propagate MessageAttributes to the consumer.  In order for the consumer to receive these,
+you will need to configure the consumer's subscription with `RawMessageDelivery`
+
+    aws sns set-subscription-attributes --attribute-name RawMessageDelivery --attribute-value true --subscription-arn arn:aws:sns:us-east-1:1465414804035:e9126059-9eab-4b37-8194-e0d64dfb2045
+    
+Publishing to an SNS topic is a one way operation, so adding these to the message by itself has little value
+unless you configure a subscription with a consumer that is smart enough to read the attributes. If you are consuming the topic 
+messages via SQS, [SmartThings Brave SQS](https://github.com/SmartThingsOSS/smartthings-brave/tree/master/brave-sqs) will handle this.   
+    
+   

--- a/brave-sns/pom.xml
+++ b/brave-sns/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2017 SmartThings
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>smartthings.brave</groupId>
+        <artifactId>smartthings-brave-parent</artifactId>
+        <version>0.3.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smartthings-brave-sns</artifactId>
+    <packaging>jar</packaging>
+
+    <name>smartthings-brave-sns</name>
+    <description>Brave SNS client tracing</description>
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <properties>
+        <main.basedir>${project.basedir}/..</main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sns</artifactId>
+            <version>1.11.164</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/brave-sns/src/main/java/smartthings/brave/sns/AmazonSNSB3Propagation.java
+++ b/brave-sns/src/main/java/smartthings/brave/sns/AmazonSNSB3Propagation.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2016-2017 SmartThings
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package smartthings.brave.sns;
+
+import brave.propagation.Propagation;
+import com.amazonaws.services.sns.model.MessageAttributeValue;
+
+import java.util.Map;
+
+public final class AmazonSNSB3Propagation {
+
+  private AmazonSNSB3Propagation() {
+  }
+
+  public static final Propagation.Getter<Map<String, MessageAttributeValue>, String> EXTRACTOR =
+    (carrier, key) -> {
+      if (carrier.containsKey(key)) {
+        return carrier.get(key).getStringValue();
+      } else {
+        return null;
+      }
+    };
+
+  public static final Propagation.Setter<Map<String, MessageAttributeValue>, String> INJECTOR =
+    (carrier, key, v) -> {
+      if (v == null) {
+        carrier.remove(key);
+      } else {
+        carrier.put(key,
+          new MessageAttributeValue().withDataType("String").withStringValue(v));
+      }
+    };
+}

--- a/brave-sns/src/main/java/smartthings/brave/sns/PublishRequestTracingHandler.java
+++ b/brave-sns/src/main/java/smartthings/brave/sns/PublishRequestTracingHandler.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2016-2017 SmartThings
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package smartthings.brave.sns;
+
+import brave.Span;
+import brave.Tracing;
+import brave.propagation.TraceContext;
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.Request;
+import com.amazonaws.Response;
+import com.amazonaws.handlers.RequestHandler2;
+import com.amazonaws.services.sns.model.MessageAttributeValue;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.PublishResult;
+
+import zipkin2.Endpoint;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * AWS RequestHandler2 that adds tracing around the afterError and afterResponse events
+ * when calling the AWS SNS publish API.
+ */
+public class PublishRequestTracingHandler extends RequestHandler2 {
+
+  private static final String SNS_TOPIC_ARN = "sns.topic_arn";
+  private static final String SNS_MESSAGE_ID = "sns.msg_id";
+
+  private static final String SERVICE_NAME = "AmazonSNS";
+
+  private static final Logger logger = Logger.getLogger(PublishRequestTracingHandler.class.getName());
+
+  protected Tracing tracing;
+  protected final TraceContext.Injector<Map<String, MessageAttributeValue>> injector;
+  protected final TraceContext.Extractor<Map<String, MessageAttributeValue>> extractor;
+
+  public PublishRequestTracingHandler(Tracing tracing) {
+    this.tracing = tracing;
+    this.injector = tracing.propagation().injector(AmazonSNSB3Propagation.INJECTOR);
+    this.extractor = tracing.propagation().extractor(AmazonSNSB3Propagation.EXTRACTOR);
+  }
+
+  @Override
+  public void afterError(Request<?> request, Response<?> response, Exception e) {
+    if (request.getOriginalRequestObject() instanceof PublishRequest) {
+      Span span =  tracing.tracer().nextSpan()
+        .remoteEndpoint(Endpoint.newBuilder().serviceName(SERVICE_NAME).build())
+        .kind(Span.Kind.CLIENT)
+        .start();
+
+      span.tag("error", e.getMessage());
+      span.flush();
+    }
+  }
+
+  @Override
+  public AmazonWebServiceRequest beforeMarshalling(AmazonWebServiceRequest request) {
+    if (request instanceof PublishRequest) {
+      PublishRequest publishRequest = (PublishRequest) request;
+
+      Span oneWay = tracing.tracer().nextSpan()
+        .remoteEndpoint(Endpoint.newBuilder().serviceName(SERVICE_NAME).build())
+        .kind(Span.Kind.CLIENT)
+        .start();
+
+      injector.inject(oneWay.context(), publishRequest.getMessageAttributes());
+
+      String name = "unknown_topic";
+      if (publishRequest.getTopicArn() != null) {
+        name = publishRequest.getTopicArn();
+      }
+      oneWay.name(name);
+      oneWay.tag(SNS_TOPIC_ARN, name);
+
+      tracing.tracer().withSpanInScope(oneWay);
+    }
+    return request;
+  }
+
+  @Override
+  public void afterResponse(Request<?> request, Response<?> response) {
+    if (response.getAwsResponse() instanceof PublishResult) {
+      PublishResult publishResult = (PublishResult) response.getAwsResponse();
+
+      Span span = tracing.tracer().currentSpan();
+
+      if (publishResult != null && publishResult.getMessageId() != null) {
+        span.tag(SNS_MESSAGE_ID, publishResult.getMessageId());
+        span.flush();
+      }
+    }
+  }
+}

--- a/brave-sns/src/test/java/smartthings/brave/sns/PublishRequestTracingHandlerTest.java
+++ b/brave-sns/src/test/java/smartthings/brave/sns/PublishRequestTracingHandlerTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2016-2017 SmartThings
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package smartthings.brave.sns;
+
+import brave.Tracing;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.StrictCurrentTraceContext;
+import brave.propagation.TraceContext;
+import com.amazonaws.DefaultRequest;
+import com.amazonaws.Request;
+import com.amazonaws.Response;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.PublishResult;
+import org.junit.Test;
+import zipkin2.Span;
+
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+
+public class PublishRequestTracingHandlerTest {
+
+  private CurrentTraceContext currentTraceContext = new StrictCurrentTraceContext();
+  private ConcurrentLinkedDeque<Span> spans = new ConcurrentLinkedDeque<>();
+
+  private Tracing tracing = Tracing.newBuilder()
+    .spanReporter(s -> {
+      // make sure the context was cleared prior to finish.. no leaks!
+      TraceContext current = currentTraceContext.get();
+      if (current != null) {
+        assertThat(current.spanId())
+          .isNotEqualTo(s.id());
+      }
+      spans.add(s);
+    })
+    .currentTraceContext(currentTraceContext)
+    .build();
+
+  private PublishRequestTracingHandler handler = new PublishRequestTracingHandler(tracing);
+
+  @Test
+  public void canTracePublish() {
+    PublishRequest publishRequest = new PublishRequest("topic", "1234");
+    PublishResult publishResult = new PublishResult().withMessageId("54321");
+
+    Request request = new DefaultRequest(publishRequest, "amazon-sns");
+    Response response = new Response(publishResult, null);
+
+    handler.beforeMarshalling(publishRequest);
+    //do stuff
+    handler.afterResponse(request, response);
+    assertEquals( 1, spans.size() );
+  }
+
+  @Test
+  public void canTracePublishError() {
+    PublishRequest publishRequest = new PublishRequest("topic", "1234");
+    PublishResult publishResult = new PublishResult().withMessageId("54321");
+
+    Request request = new DefaultRequest(publishRequest, "amazon-sns");
+    Response response = new Response(publishResult, null);
+
+    handler.afterError(request, response, new Exception("Aw, snap!"));
+    assertEquals( 1, spans.size() );
+    assertEquals(spans.getFirst().tags().get("error"), "Aw, snap!");
+  }
+  @Test
+  public void canTracePublishRequestError() {
+    PublishRequest publishRequest = new PublishRequest("topic", "1234");
+    Request request = new DefaultRequest(publishRequest, "amazon-sns");
+
+    handler.afterError(request, null, new Exception("Aw, snap!"));
+    assertEquals( 1, spans.size() );
+    assertEquals(spans.getFirst().tags().get("error"), "Aw, snap!");
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
     <module>brave-http-common</module>
     <module>brave-cassandra-common</module>
     <module>brave-sqs</module>
+    <module>brave-sns</module>
   </modules>
 
   <distributionManagement>


### PR DESCRIPTION
Adds a request handler that can be added to a AWS SNS client to add tracing to the message attributes when publishing a message to a topic.

cc @llinder 

