### PR TITLE
Allow external usage of AsyncHttpClient filter tracing classes

### DIFF
--- a/brave-asynchttpclient/brave-asynchttpclient-2.x/src/main/java/smartthings/brave/asynchttpclient/ClientTracing.java
+++ b/brave-asynchttpclient/brave-asynchttpclient-2.x/src/main/java/smartthings/brave/asynchttpclient/ClientTracing.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 SmartThings
+ * Copyright 2016-2018 SmartThings
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -61,7 +61,7 @@ public class ClientTracing {
 
   public static final class TracingRequestFilter extends TracingFilter implements RequestFilter {
 
-    TracingRequestFilter(HttpTracing httpTracing) {
+    public TracingRequestFilter(HttpTracing httpTracing) {
       super(httpTracing);
     }
 
@@ -88,7 +88,7 @@ public class ClientTracing {
   public static final class TracingResponseFilter extends TracingFilter implements ResponseFilter {
 
 
-    TracingResponseFilter(HttpTracing httpTracing) {
+    public TracingResponseFilter(HttpTracing httpTracing) {
       super(httpTracing);
     }
 
@@ -130,7 +130,7 @@ public class ClientTracing {
 
     private final HttpTracing httpTracing;
 
-    TracingIOExceptionFilter(HttpTracing httpTracing) {
+    public TracingIOExceptionFilter(HttpTracing httpTracing) {
       super(httpTracing);
       this.httpTracing = httpTracing;
     }

--- a/brave-asynchttpclient/brave-asynchttpclient-2.x/src/test/java/smartthings/brave/asynchttpclient/ITClientTracing.java
+++ b/brave-asynchttpclient/brave-asynchttpclient-2.x/src/test/java/smartthings/brave/asynchttpclient/ITClientTracing.java
@@ -31,7 +31,7 @@ public class ITClientTracing extends ITHttpClient<AsyncHttpClient> {
       .instrument(new DefaultAsyncHttpClientConfig.Builder(), httpTracing)
       .setFollowRedirect(true)
       .setMaxRequestRetry(1)
-      .setRequestTimeout(100)
+      .setRequestTimeout(1000)
       .build();
 
     return new DefaultAsyncHttpClient(config);


### PR DESCRIPTION
Required by SmartThingsOSS/dropwizard-common#50