### PR TITLE
Fix API usage error introduced in asynchttpclient 2.1

### DIFF
--- a/brave-asynchttpclient/brave-asynchttpclient-2.x/pom.xml
+++ b/brave-asynchttpclient/brave-asynchttpclient-2.x/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <main.basedir>${project.basedir}/../..</main.basedir>
-        <asynchttpclient.version>2.0.0</asynchttpclient.version>
+        <asynchttpclient.version>2.4.9</asynchttpclient.version>
     </properties>
 
     <dependencies>

--- a/brave-asynchttpclient/brave-asynchttpclient-2.x/src/main/java/smartthings/brave/asynchttpclient/ClientTracing.java
+++ b/brave-asynchttpclient/brave-asynchttpclient-2.x/src/main/java/smartthings/brave/asynchttpclient/ClientTracing.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 SmartThings
+ * Copyright 2016-2018 SmartThings
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,7 +23,6 @@ import io.netty.handler.codec.http.HttpHeaders;
 import org.asynchttpclient.AsyncHandler;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import org.asynchttpclient.HttpResponseBodyPart;
-import org.asynchttpclient.HttpResponseHeaders;
 import org.asynchttpclient.HttpResponseStatus;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.RequestBuilder;
@@ -107,7 +106,7 @@ public class ClientTracing {
         if (ctx.getResponseStatus().getStatusCode() == 301 || ctx.getResponseStatus().getStatusCode() == 302) {
 
           // need to send the redirect URL to the tracer handleSend
-          String redirectUrl = ctx.getResponseHeaders().getHeaders().get("Location");
+          String redirectUrl = ctx.getResponseHeaders().get("Location");
           Request dummyRequest = new RequestBuilder(ctx.getRequest()).setUrl(redirectUrl).build();
 
           try (CurrentTraceContext.Scope scope = currentTraceContext.newScope(parent)) {
@@ -233,7 +232,7 @@ public class ClientTracing {
       }
     }
 
-    @Override public State onHeadersReceived(HttpResponseHeaders headers)
+    @Override public State onHeadersReceived(HttpHeaders headers)
       throws Exception {
       if (delegate != null) {
         return this.delegate.onHeadersReceived(headers);

--- a/brave-asynchttpclient/brave-asynchttpclient-2.x/src/test/java/smartthings/brave/asynchttpclient/ITClientTracing.java
+++ b/brave-asynchttpclient/brave-asynchttpclient-2.x/src/test/java/smartthings/brave/asynchttpclient/ITClientTracing.java
@@ -31,7 +31,7 @@ public class ITClientTracing extends ITHttpClient<AsyncHttpClient> {
       .instrument(new DefaultAsyncHttpClientConfig.Builder(), httpTracing)
       .setFollowRedirect(true)
       .setMaxRequestRetry(1)
-      .setRequestTimeout(100)
+      .setRequestTimeout(1000)
       .build();
 
     return new DefaultAsyncHttpClient(config);


### PR DESCRIPTION
In AsyncHttpClient/async-http-client@f4786f3ac7699f8f8664e7c7db0b7097585a0786 `org.asynchttpclient.HttpResponseHeaders` was removed in favor of `io.netty.handler.codec.http.HttpHeaders`. This fixes brave-asynchttpclient against recent versions of asynchttpclient, by using the correctly classes agaist asynchttpclient API.

Target the most recent versin of asynchttpclient: 2.4.9.